### PR TITLE
Include headers from external folder in rdkit-dev

### DIFF
--- a/recipe/install_rdkit_dev.bat
+++ b/recipe/install_rdkit_dev.bat
@@ -9,3 +9,11 @@ copy lib\*.lib %LIBRARY_LIB%
 REM copy .h files to LIBRARY_INC
 mkdir %LIBRARY_INC%\rdkit
 xcopy /y /s Code\*.h %LIBRARY_INC%\rdkit
+
+REM copy external .h files to LIBRARY_INC
+xcopy /y External\INCHI-API\*.h %LIBRARY_INC%\rdkit\GraphMol
+xcopy /y External\AvalonTools\*.h %LIBRARY_INC%\rdkit\GraphMol
+xcopy /y External\FreeSASA\*.h %LIBRARY_INC%\rdkit\GraphMol
+xcopy /y External\CoordGen\*.h %LIBRARY_INC%\rdkit\GraphMol
+xcopy /y External\YAeHMOP\*.h %LIBRARY_INC%\rdkit\GraphMol
+xcopy /y External\RingFamilies\RingDecomposerLib\src\RingDecomposerLib\RingDecomposerLib.h %LIBRARY_INC%\rdkit

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: efcaaeb74a888f503a244e6d5c4d7d766c6a204592c8f182db74eb0ed923abda
 
 build:
-  number: 2
+  number: 3
   skip: true  # [py27]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Just realized that all headers from External directory (in source) are not included in the newly created rdkit-dev subpackage. This PR is to fix that.

<!--
Please add any other relevant info below:
-->
