### PR TITLE
bump rdkit version

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,21 +8,21 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.20python3.8.____cpython:
-        CONFIG: linux_64_numpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.20python3.8.____cpython
-      linux_64_numpy1.20python3.9.____cpython:
-        CONFIG: linux_64_numpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.20python3.9.____cpython
       linux_64_numpy1.21python3.10.____cpython:
         CONFIG: linux_64_numpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: linux_64_numpy1.21python3.10.____cpython
+      linux_64_numpy1.21python3.8.____cpython:
+        CONFIG: linux_64_numpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_numpy1.21python3.8.____cpython
+      linux_64_numpy1.21python3.9.____cpython:
+        CONFIG: linux_64_numpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_numpy1.21python3.9.____cpython
       linux_64_numpy1.23python3.11.____cpython:
         CONFIG: linux_64_numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,34 +8,34 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_numpy1.20python3.8.____cpython:
-        CONFIG: osx_64_numpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.20python3.8.____cpython
-      osx_64_numpy1.20python3.9.____cpython:
-        CONFIG: osx_64_numpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.20python3.9.____cpython
       osx_64_numpy1.21python3.10.____cpython:
         CONFIG: osx_64_numpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: osx_64_numpy1.21python3.10.____cpython
+      osx_64_numpy1.21python3.8.____cpython:
+        CONFIG: osx_64_numpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_numpy1.21python3.8.____cpython
+      osx_64_numpy1.21python3.9.____cpython:
+        CONFIG: osx_64_numpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_numpy1.21python3.9.____cpython
       osx_64_numpy1.23python3.11.____cpython:
         CONFIG: osx_64_numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: osx_64_numpy1.23python3.11.____cpython
-      osx_arm64_numpy1.20python3.8.____cpython:
-        CONFIG: osx_arm64_numpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_arm64_numpy1.20python3.8.____cpython
-      osx_arm64_numpy1.20python3.9.____cpython:
-        CONFIG: osx_arm64_numpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_arm64_numpy1.20python3.9.____cpython
       osx_arm64_numpy1.21python3.10.____cpython:
         CONFIG: osx_arm64_numpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: osx_arm64_numpy1.21python3.10.____cpython
+      osx_arm64_numpy1.21python3.8.____cpython:
+        CONFIG: osx_arm64_numpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_numpy1.21python3.8.____cpython
+      osx_arm64_numpy1.21python3.9.____cpython:
+        CONFIG: osx_arm64_numpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_numpy1.21python3.9.____cpython
       osx_arm64_numpy1.23python3.11.____cpython:
         CONFIG: osx_arm64_numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -5,21 +5,21 @@
 jobs:
 - job: win
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   strategy:
     matrix:
-      win_64_numpy1.20python3.8.____cpython:
-        CONFIG: win_64_numpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_numpy1.20python3.8.____cpython
-      win_64_numpy1.20python3.9.____cpython:
-        CONFIG: win_64_numpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_numpy1.20python3.9.____cpython
       win_64_numpy1.21python3.10.____cpython:
         CONFIG: win_64_numpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: win_64_numpy1.21python3.10.____cpython
+      win_64_numpy1.21python3.8.____cpython:
+        CONFIG: win_64_numpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: win_64_numpy1.21python3.8.____cpython
+      win_64_numpy1.21python3.9.____cpython:
+        CONFIG: win_64_numpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: win_64_numpy1.21python3.9.____cpython
       win_64_numpy1.23python3.11.____cpython:
         CONFIG: win_64_numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -49,7 +49,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.10" conda-build conda pip boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1

--- a/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:

--- a/.ci_support/linux_64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.8.____cpython.yaml
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   boost:
     max_pin: x.x.x
@@ -25,7 +25,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.9.____cpython.yaml
@@ -2,16 +2,22 @@ boost:
 - 1.78.0
 cairo:
 - '1'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   boost:
     max_pin: x.x.x
@@ -19,9 +25,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- win-64
+- linux-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+MACOSX_SDK_VERSION:
+- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 freetype:
 - '2'
 macos_machine:

--- a/.ci_support/osx_64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.8.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+MACOSX_SDK_VERSION:
+- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.8.____cpython.yaml
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 freetype:
 - '2'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   boost:
     max_pin: x.x.x
@@ -25,7 +25,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.9.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+MACOSX_SDK_VERSION:
+- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.9.____cpython.yaml
@@ -1,3 +1,5 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 boost:
 - 1.78.0
 cairo:
@@ -7,11 +9,15 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- clangxx
+cxx_compiler_version:
+- '15'
 freetype:
 - '2'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   boost:
     max_pin: x.x.x
@@ -21,7 +27,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- win-64
+- osx-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+MACOSX_SDK_VERSION:
+- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 freetype:
 - '2'
 macos_machine:

--- a/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-MACOSX_SDK_VERSION:
-- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 freetype:
 - '2'
 macos_machine:

--- a/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.10.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
+MACOSX_SDK_VERSION:
+- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_arm64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.8.____cpython.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-MACOSX_SDK_VERSION:
-- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_arm64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.8.____cpython.yaml
@@ -1,23 +1,23 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 boost:
 - 1.78.0
 cairo:
 - '1'
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '11'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
 freetype:
 - '2'
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   boost:
     max_pin: x.x.x
@@ -27,7 +27,7 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_arm64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.8.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
+MACOSX_SDK_VERSION:
+- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_arm64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.9.____cpython.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-MACOSX_SDK_VERSION:
-- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_arm64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.9.____cpython.yaml
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 freetype:
 - '2'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   boost:
     max_pin: x.x.x
@@ -25,7 +25,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.9.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
+MACOSX_SDK_VERSION:
+- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-MACOSX_SDK_VERSION:
-- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 freetype:
 - '2'
 macos_machine:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
+MACOSX_SDK_VERSION:
+- '10.13'
 boost:
 - 1.78.0
 cairo:

--- a/.ci_support/win_64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.8.____cpython.yaml
@@ -1,5 +1,3 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 boost:
 - 1.78.0
 cairo:
@@ -9,15 +7,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '14'
+- vs2019
 freetype:
 - '2'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   boost:
     max_pin: x.x.x
@@ -27,7 +21,7 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 target_platform:
-- osx-64
+- win-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.9.____cpython.yaml
@@ -1,5 +1,3 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 boost:
 - 1.78.0
 cairo:
@@ -9,15 +7,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '14'
+- vs2019
 freetype:
 - '2'
-macos_machine:
-- arm64-apple-darwin20.0.0
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   boost:
     max_pin: x.x.x
@@ -27,7 +21,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- osx-arm64
+- win-64
 zip_keys:
 - - python
   - numpy

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/create_conda_build_artifacts.bat
+++ b/.scripts/create_conda_build_artifacts.bat
@@ -54,8 +54,8 @@ if defined BLD_ARTIFACT_PREFIX (
         echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
     )
     if "%CI%" == "github_actions" (
-        echo ::set-output name=BLD_ARTIFACT_NAME::!BLD_ARTIFACT_NAME!
-        echo ::set-output name=BLD_ARTIFACT_PATH::!BLD_ARTIFACT_PATH!
+        echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
+        echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
     )
 )
 
@@ -74,7 +74,7 @@ if defined ENV_ARTIFACT_PREFIX (
         echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
     )
     if "%CI%" == "github_actions" (
-        echo ::set-output name=ENV_ARTIFACT_NAME::!ENV_ARTIFACT_NAME!
-        echo ::set-output name=ENV_ARTIFACT_PATH::!ENV_ARTIFACT_PATH!
+        echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
+        echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
     )
 )

--- a/.scripts/create_conda_build_artifacts.sh
+++ b/.scripts/create_conda_build_artifacts.sh
@@ -79,8 +79,8 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
         echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
         echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
     elif [[ "$CI" == "github_actions" ]]; then
-        echo "::set-output name=BLD_ARTIFACT_NAME::$BLD_ARTIFACT_NAME"
-        echo "::set-output name=BLD_ARTIFACT_PATH::$BLD_ARTIFACT_PATH"
+        echo "BLD_ARTIFACT_NAME=$BLD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "BLD_ARTIFACT_PATH=$BLD_ARTIFACT_PATH" >> $GITHUB_OUTPUT
     fi
 fi
 
@@ -107,7 +107,7 @@ if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
         echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
         echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
     elif [[ "$CI" == "github_actions" ]]; then
-        echo "::set-output name=ENV_ARTIFACT_NAME::$ENV_ARTIFACT_NAME"
-        echo "::set-output name=ENV_ARTIFACT_PATH::$ENV_ARTIFACT_PATH"
+        echo "ENV_ARTIFACT_NAME=$ENV_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "ENV_ARTIFACT_PATH=$ENV_ARTIFACT_PATH" >> $GITHUB_OUTPUT
     fi
 fi

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -24,9 +24,9 @@ source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,28 @@
+About rdkit-feedstock
+=====================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/rdkit-feedstock/blob/main/LICENSE.txt)
+
 About rdkit
-===========
+-----------
 
 Home: http://rdkit.org
 
 Package license: BSD-3-Clause
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/rdkit-feedstock/blob/main/LICENSE.txt)
 
 Summary: RDKit is a collection of cheminformatics and machine-learning software written in C++ and Python.
 
 Development: https://github.com/rdkit/rdkit
 
 Documentation: http://www.rdkit.org/docs/index.html
+About rdkit-dev
+---------------
+
+
+
+Package license: BSD-3-Clause
+
+Summary: RDKit headers and library used in rdkit package
 
 Current build status
 ====================
@@ -31,24 +42,24 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.20python3.8.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.20python3.8.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_numpy1.20python3.9.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.20python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.21python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -59,24 +70,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.20python3.8.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.20python3.8.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>osx_64_numpy1.20python3.9.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.20python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>osx_64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.21python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -87,24 +98,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_numpy1.20python3.8.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.20python3.8.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>osx_arm64_numpy1.20python3.9.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.20python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>osx_arm64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.21python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.21python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.21python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -115,24 +126,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.20python3.8.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.20python3.8.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>win_64_numpy1.20python3.9.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.20python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>win_64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.21python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1832&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rdkit-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -272,6 +283,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@greglandrum](https://github.com/greglandrum/)
 * [@jaimergp](https://github.com/jaimergp/)
 * [@mcs07](https://github.com/mcs07/)
 * [@pstjohn](https://github.com/pstjohn/)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,11 @@ if [[ "$target_platform" == linux-ppc64le ]]; then
     EXTRA_CMAKE_FLAGS+=" -D PYTHON_NUMPY_INCLUDE_PATH=${SP_DIR}/numpy/core/include"
 fi
 
+# workaround for clang++ and boost functional
+if [[ "$target_platform" == osx-arm64 ]] || [[ "$target_platform" == osx-64 ]]; then
+    export CXXFLAGS="-D_HAS_AUTO_PTR_ETC=0"
+fi
+
 cmake ${CMAKE_ARGS} \
     -D CMAKE_BUILD_TYPE=Release \
     -D CMAKE_INSTALL_PREFIX="$PREFIX" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,7 +17,7 @@ fi
 
 # workaround for clang++ and boost functional
 if [[ "$target_platform" == osx-arm64 ]] || [[ "$target_platform" == osx-64 ]]; then
-    export CXXFLAGS="-D_HAS_AUTO_PTR_ETC=0"
+    export CXXFLAGS="-D_HAS_AUTO_PTR_ETC=0 $CXXFLAGS"
 fi
 
 cmake ${CMAKE_ARGS} \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+MACOSX_SDK_VERSION:        # [osx]
+  - "10.13"                # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
-MACOSX_SDK_VERSION:        # [osx]
-  - "10.13"                # [osx]
+MACOSX_SDK_VERSION:        # [osx and x86_64]
+  - "10.13"                # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rdkit" %}
-{% set version = "2023.01.1" %}
+{% set version = "2023.03.1" %}
 {% set filename = "Release_%s.tar.gz" % version.replace(".", "_") %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rdkit" %}
-{% set version = "2022.09.5" %}
+{% set version = "2023.01.1" %}
 {% set filename = "Release_%s.tar.gz" % version.replace(".", "_") %}
 
 package:
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ filename }}
   url: https://github.com/rdkit/rdkit/archive/{{ filename }}
-  sha256: 2efe7ce3b527df529ed3e355e2aaaf14623e51876be460fa4ad2b7f7ad54c9b1
+  sha256: db346afbd0ba52c843926a2a62f8a38c7b774ffab37eaf382d789a824f21996c
 
 build:
   number: 0


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Two things here:
1. Bumps the version to 2023.03.1
2. Adds an additional compile flag on OSX to workaround some weirdness in boost::functional and boost::container_hash
