### PR TITLE
Enable building RDKit stubs as part of the conda-forge recipe starting from Release 2023_09_6

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,7 +14,6 @@ cmake ^
     -D RDK_BUILD_FREESASA_SUPPORT=ON ^
     -D RDK_BUILD_YAEHMOP_SUPPORT=ON ^
     -D RDK_BUILD_XYZ2MOL_SUPPORT=ON ^
-    -D RDK_BUILD_PYTHON_STUBS=ON ^
     -D RDK_INSTALL_STATIC_LIBS=OFF ^
     -D RDK_INSTALL_DLLS_MSVC=ON ^
     -D RDK_INSTALL_DEV_COMPONENT=OFF ^
@@ -30,6 +29,10 @@ if errorlevel 1 exit 1
 
 REM copy .dll files to LIBRARY_BIN
 copy bin\*.dll %LIBRARY_BIN%
+
+@REM NOTE(ptosco): build and install rdkit-stubs
+cmake --build . --config Release --target stubs
+if errorlevel 1 exit 1
 
 @REM NOTE(hadim): below we run `pip install ...` in order
 @REM to correctly add the `.dist-info` directory in the package

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,7 +34,6 @@ cmake ${CMAKE_ARGS} \
     -D RDK_BUILD_FREESASA_SUPPORT=ON \
     -D RDK_BUILD_YAEHMOP_SUPPORT=ON \
     -D RDK_BUILD_XYZ2MOL_SUPPORT=ON \
-    -D RDK_BUILD_PYTHON_STUBS=ON \
     -D RDK_INSTALL_INTREE=OFF \
     -D RDK_INSTALL_STATIC_LIBS=OFF \
     -D RDK_OPTIMIZE_POPCNT=${POPCNT_OPTIMIZATION} \
@@ -43,6 +42,8 @@ cmake ${CMAKE_ARGS} \
 
 make -j$CPU_COUNT
 make install
+# NOTE(ptosco): build and install rdkit-stubs
+cmake --build . --config Release --target stubs
 
 ## How to run unit tests:
 ## 1. Set RDK_BUILD_CPP_TESTS to ON

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - pip
     - setuptools
     - setuptools_scm >=8
-    # For rdkit-tubs
+    # For rdkit-stubs
     - pybind11-stubgen
   run:
     - cairo


### PR DESCRIPTION
This PR contributes a couple of small changes to enable building RDKit stubs as part of the `conda-forge` recipe.
The stubs are correctly build and included in the `tar.bz2` artifact on all supported platforms.

Please note that for the build to succeed on Windows, a small fix is also needed on the RDKit side, as documented in this PR:
https://github.com/rdkit/rdkit/pull/7191

PR #7191 has the `2023_09_6` milestone, so it is expected that the `conda-forge` builds for the `2023_09_6` RDKit release should contain RDKit stubs on all platforms if this PR is accepted.

- modified build recipes to enable building `rdkit-stubs`
- fixed typo and added comments
