### PR TITLE
limit pandas version to <2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - pyproject.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [aarch64]
   missing_dso_whitelist:
     - '*/RDKit*dll'  # [win]
@@ -38,7 +38,7 @@ requirements:
     - python
     - numpy
     - pillow
-    - pandas
+    - pandas <2.2
     - pip
     - setuptools
     - setuptools_scm >=8
@@ -48,7 +48,7 @@ requirements:
     - cairo
     - python
     - pillow
-    - pandas
+    - pandas <2.2
     - {{ pin_compatible('numpy') }}
     - pycairo
     - matplotlib-base


### PR DESCRIPTION
There's an unexpected problem with pandas versions >=2.2, so this locks the version

Checklist
* [x ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x ] Ensured the license file is being packaged.

