### PR TITLE
limit pandas version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - pyproject.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [aarch64]
   missing_dso_whitelist:
     - '*/RDKit*dll'  # [win]
@@ -38,7 +38,7 @@ requirements:
     - python
     - numpy
     - pillow
-    - pandas
+    - pandas <2.2
     - pip
     - setuptools
     - setuptools_scm >=8
@@ -48,7 +48,7 @@ requirements:
     - cairo
     - python
     - pillow
-    - pandas
+    - pandas <2.2
     - {{ pin_compatible('numpy') }}
     - pycairo
     - matplotlib-base
@@ -74,6 +74,7 @@ test:
     - rdkit.SimDivFilters
     - rdkit.VLib
     - rdkit.VLib.NodeLib
+    - rdkit.Chem.PandasTools
 
 outputs:
   - name: rdkit


### PR DESCRIPTION
The change to upstream which was intended to make things work with pandas 2.2 seems to not have worked.
This caps the pandas version until we can get that resolved

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

