### PR TITLE
Fixes for librdkit-dev and rdkit-postgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ About rdkit-dev
 
 Package license: BSD-3-Clause
 
-Summary: Alias for librdkit-dev + rdkit
+Summary: Alias package for librdkit-dev + rdkit
 
 Current build status
 ====================

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -33,10 +33,4 @@ elif [ "${PKG_NAME}" == "rdkit-postgresql" ]; then
     cd ./Code/PgSQL/rdkit
     cmake -P cmake_install.cmake
 
-    if [ "${target_platform}" == "osx-arm64" ] || [ "${target_platform}" == "osx-64" ]; then
-      # NOTE(skearnes): PostgreSQL doesn't recognize `rdkit.so` on OSX.
-      DIR="$(pg_config --pkglibdir)"
-      mv "${DIR}"/rdkit.so "${DIR}"/rdkit.dylib
-    fi
-
 fi

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -30,12 +30,13 @@ elif [ "${PKG_NAME}" == "rdkit" ]; then
 
 elif [ "${PKG_NAME}" == "rdkit-postgresql" ]; then
 
+    cd ./Code/PgSQL/rdkit
+    cmake -P cmake_install.cmake
+
     if [ "${target_platform}" == "osx-arm64" ] || [ "${target_platform}" == "osx-64" ]; then
       # NOTE(skearnes): PostgreSQL doesn't recognize `rdkit.so` on OSX.
       DIR="$(pg_config --pkglibdir)"
-      ln -s "${DIR}"/rdkit.so "${DIR}"/rdkit.dylib
+      mv "${DIR}"/rdkit.so "${DIR}"/rdkit.dylib
     fi
-    cd ./Code/PgSQL/rdkit
-    cmake -P cmake_install.cmake
 
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -194,7 +194,7 @@ outputs:
         - rdkit.VLib.NodeLib
         - rdkit.Chem.PandasTools
     about:
-      summary: Alias for librdkit-dev + rdkit
+      summary: Alias package for librdkit-dev + rdkit
       license: BSD-3-Clause
       license_file: license.txt
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
 
   patches:
     - pyproject.patch
+    - rdkit-postgresql-osx.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -166,6 +166,38 @@ outputs:
       license: BSD-3-Clause
       license_file: license.txt
 
+  - name: rdkit-dev
+    requirements:
+      run:
+        - {{ pin_subpackage('librdkit-dev', exact=True) }}
+        - {{ pin_subpackage('rdkit', exact=True) }}
+    test:
+      commands:
+        - test -f $PREFIX/include/rdkit/GraphMol/GraphMol.h               # [unix]
+        - if not exist %LIBRARY_INC%\\rdkit\\GraphMol\\GraphMol.h exit 1  # [win]
+        - python -c "import rdkit; assert rdkit.__version__ == '{{ version }}'"
+      imports:
+        - rdkit
+        - rdkit.Avalon
+        - rdkit.Chem
+        - rdkit.Chem.AllChem
+        - rdkit.Chem.rdFreeSASA
+        - rdkit.DataManip
+        - rdkit.Dbase
+        - rdkit.DistanceGeometry
+        - rdkit.ForceField
+        - rdkit.Geometry
+        - rdkit.ML
+        - rdkit.Numerics
+        - rdkit.SimDivFilters
+        - rdkit.VLib
+        - rdkit.VLib.NodeLib
+        - rdkit.Chem.PandasTools
+    about:
+      summary: Alias for librdkit-dev + rdkit
+      license: BSD-3-Clause
+      license_file: license.txt
+
   - name: rdkit-postgresql
     script: install.sh   # [unix]
     script: install.bat  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - pyproject.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [aarch64]
   missing_dso_whitelist:
     - '*/RDKit*dll'  # [win]

--- a/recipe/rdkit-postgresql-osx.patch
+++ b/recipe/rdkit-postgresql-osx.patch
@@ -1,21 +1,22 @@
-From c003156bc3e3236fc46b60152a757aea7de49800 Mon Sep 17 00:00:00 2001
+From a8041f6139a1c2d37d87a96b87bb5a155616d87a Mon Sep 17 00:00:00 2001
 From: Steven Kearnes <skearnes@gmail.com>
-Date: Wed, 24 Jul 2024 20:23:37 -0400
+Date: Wed, 24 Jul 2024 20:44:12 -0400
 Subject: [PATCH] patch
 
 ---
- Code/PgSQL/rdkit/CMakeLists.txt | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ Code/PgSQL/rdkit/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Code/PgSQL/rdkit/CMakeLists.txt b/Code/PgSQL/rdkit/CMakeLists.txt
-index 5a66ac4dd..8e81bd007 100644
+index 5a66ac4dd..c5125119a 100644
 --- a/Code/PgSQL/rdkit/CMakeLists.txt
 +++ b/Code/PgSQL/rdkit/CMakeLists.txt
 @@ -1,7 +1,7 @@
  if(APPLE)
    set (EXTENSION_PREFIX "")
-   set (EXTENSION_SUFFIX ".so")
+-  set (EXTENSION_SUFFIX ".so")
 -  set (EXTENSION_DEST_SUFFIX ".so")
++  set (EXTENSION_SUFFIX ".dylib")
 +  set (EXTENSION_DEST_SUFFIX ".dylib")
  elseif(WIN32)
    set(REGEX_SEPARATOR "\\\\")

--- a/recipe/rdkit-postgresql-osx.patch
+++ b/recipe/rdkit-postgresql-osx.patch
@@ -1,0 +1,25 @@
+From c003156bc3e3236fc46b60152a757aea7de49800 Mon Sep 17 00:00:00 2001
+From: Steven Kearnes <skearnes@gmail.com>
+Date: Wed, 24 Jul 2024 20:23:37 -0400
+Subject: [PATCH] patch
+
+---
+ Code/PgSQL/rdkit/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Code/PgSQL/rdkit/CMakeLists.txt b/Code/PgSQL/rdkit/CMakeLists.txt
+index 5a66ac4dd..8e81bd007 100644
+--- a/Code/PgSQL/rdkit/CMakeLists.txt
++++ b/Code/PgSQL/rdkit/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ if(APPLE)
+   set (EXTENSION_PREFIX "")
+   set (EXTENSION_SUFFIX ".so")
+-  set (EXTENSION_DEST_SUFFIX ".so")
++  set (EXTENSION_DEST_SUFFIX ".dylib")
+ elseif(WIN32)
+   set(REGEX_SEPARATOR "\\\\")
+   if(MSVC)
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Resolves #165 

<!--
Please add any other relevant info below:
-->
* Updates `rdkit-postgresql` to avoid a symbolic link on OSX (rename to dylib instead)
* Adds `rdkit-dev` as an alias for librdkit-dev + rdkit (for backward compatibility with the old `rdkit-dev` package; see https://github.com/conda-forge/rdkit-feedstock/issues/167#issuecomment-2250376432)