### PR TITLE
add python, numpy, and boost deps to librdkit

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - rdkit-postgresql-osx.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [aarch64]
 
 requirements:
@@ -62,10 +62,15 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ stdlib("c") }}
         - cmake
+        - numpy                               # [build_platform != target_platform]
+        - python                              # [build_platform != target_platform]
       host:
         - cairo
         - freetype
         - libboost-devel
+        - libboost-python-devel
+        - python
+        - numpy
     test:
       commands:
         - test -f $PREFIX/lib/libRDKitGraphMol.so              # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,6 +61,7 @@ outputs:
       build:
         - {{ compiler("cxx") }}
         - {{ stdlib("c") }}
+        - cross-python_{{ target_platform }}  # [build_platform != target_platform]
         - cmake
         - numpy                               # [build_platform != target_platform]
         - python                              # [build_platform != target_platform]
@@ -69,6 +70,7 @@ outputs:
         - freetype
         - libboost-devel
         - libboost-python-devel
+      run_constrained:
         - python
         - numpy
     test:


### PR DESCRIPTION
This adds python, numpy, and libboost-python-devel as requirements to the build and host requirements of the `librdkit` target.
I hope this is what's required for us to end up with one librdkit per python version.

This is a bit gross since there are no actual python dependencies in there, but librdkit installs the cmake configuration files for the RDKit and those end up with the python version in them (for include paths and libraries), so I think it's necessary.

Hopefully fixes #170

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


