### PR TITLE
switch to 2024.09.1 release

### DIFF
--- a/recipe/cmake-pythonlibs.patch
+++ b/recipe/cmake-pythonlibs.patch
@@ -1,9 +1,0 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 09e3047d9..a38655da2 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -305,3 +305,3 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
-   if(WIN32 OR "${Py_ENABLE_SHARED}" STREQUAL "1")
--    target_link_libraries(rdkit_py_base INTERFACE ${Python3_LIBRARY} )
-+    target_link_libraries(rdkit_py_base INTERFACE ${Python3_LIBRARIES} )
-   endif()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2024.03.6" %}
+{% set version = "2024.09.1" %}
 {% set filename = "Release_%s.tar.gz" % version.replace(".", "_") %}
 
 package:
@@ -11,16 +11,14 @@ package:
 source:
   fn: {{ filename }}
   url: https://github.com/rdkit/rdkit/archive/{{ filename }}
-  sha256: 5002ff97e59d9c08f4faa1c6a2e276a695f6874dfc93e28cbbd62dab4f0b40d7
+  sha256: 034c00d6e9de323506834da03400761ed8c3721095114369d06805409747a60f
 
   patches:
     - pyproject.patch
     - rdkit-postgresql-osx.patch
-    # this last one can be removed with the 2024.09.1 release
-    - cmake-pythonlibs.patch
 
 build:
-  number: 1
+  number: 0
   skip: true  # [aarch64]
 
 requirements:


### PR DESCRIPTION
this also removes the now-redundant patch we added for linking the python libs

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

