### PR TITLE
Fix librdkit-dev run_exports/test block and migrate deprecated conda-forge.yml setting

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,91 +23,106 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_python3.10.____cpython
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_64_python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.11.____cpython
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_64_python3.11.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.12.____cpython
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_64_python3.12.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.13.____cp313
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_64_python3.13.____cp313
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.14.____cp314
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_64_python3.14.____cp314
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_python3.10.____cpython
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_aarch64_python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_python3.11.____cpython
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_aarch64_python3.11.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_python3.12.____cpython
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_aarch64_python3.12.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_python3.13.____cp313
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_aarch64_python3.13.____cp313
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_python3.14.____cp314
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_aarch64_python3.14.____cp314
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_python3.10.____cpython
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_ppc64le_python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_python3.11.____cpython
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_ppc64le_python3.11.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_python3.12.____cpython
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_ppc64le_python3.12.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_python3.13.____cp313
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_ppc64le_python3.13.____cp313
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_python3.14.____cp314
-            STORE_BUILD_ARTIFACTS: False
+            STORE_BUILD_ARTIFACTS: True
+            SHORT_CONFIG: linux_ppc64le_python3.14.____cp314
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -193,3 +208,84 @@ jobs:
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
+
+    - name: Determine build outcome
+      # this is to merge the status of the linux/osx/win builds into
+      # something we can easily reuse during artefact generation
+      id: determine-status
+      if: ${{ always() }}
+      shell: bash
+      env:
+        OS: ${{ matrix.os }}
+      run: |
+        if [[ "$OS" == "ubuntu" ]]; then
+          STATUS=${{ steps.build-linux.outcome }}
+        elif [[ "$OS" == "macos" ]]; then
+          STATUS=${{ steps.build-macos.outcome }}
+        elif [[ "$OS" == "windows" ]]; then
+          STATUS=${{ steps.build-windows.outcome }}
+        fi
+        if [ -z "$STATUS" ]; then
+          # steps that never ran will have empty status
+          STATUS="cancelled"
+        fi
+        echo "status=$STATUS" >> $GITHUB_OUTPUT
+
+    - name: Prepare conda build artifacts
+      continue-on-error: true
+      id: prepare-artifacts
+      shell: bash
+      # we do not want to trigger artefact creation if the build was cancelled
+      if: ${{ always() && steps.determine-status.outputs.status != 'cancelled' && matrix.STORE_BUILD_ARTIFACTS }}
+      env:
+        CI: github_actions
+        CONFIG: ${{ matrix.CONFIG }}
+        SHORT_CONFIG: ${{ matrix.SHORT_CONFIG }}
+        JOB_STATUS: ${{ steps.determine-status.outputs.status }}
+        OS: ${{ matrix.os }}
+      run: |
+        export CI_RUN_ID=$GITHUB_RUN_ID
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export ARTIFACT_STAGING_DIR="$GITHUB_WORKSPACE"
+        if [ $OS == "macos" ]; then
+          export CONDA_BLD_PATH="${MINIFORGE_HOME:-${HOME}/miniforge3}/conda-bld"
+        elif [ $OS == "windows" ]; then
+          # this needs to be consistent with build step, see above
+          export CONDA_BLD_PATH="C:\\bld"
+        else
+          export CONDA_BLD_PATH="build_artifacts"
+        fi
+        # Archive everything in CONDA_BLD_PATH except environments
+        # Archive the CONDA_BLD_PATH environments only when the job fails
+        # Use different prefix for successful and failed build artifacts
+        # so random failures don't prevent rebuilds from creating artifacts.
+        if [ $JOB_STATUS == "failure" ]; then
+          export BLD_ARTIFACT_PREFIX="conda_artifacts"
+          export ENV_ARTIFACT_PREFIX="conda_envs"
+        else
+          export BLD_ARTIFACT_PREFIX="conda_pkgs"
+        fi
+        if [ $OS == "windows" ]; then
+          pwsh -Command ". '.scripts/create_conda_build_artifacts.bat'"
+        else
+          ./.scripts/create_conda_build_artifacts.sh
+        fi
+
+    - name: Store conda build artifacts
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      if: ${{ always() && steps.prepare-artifacts.outcome == 'success' }}
+      with:
+        name: ${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_NAME }}
+        path: ${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_PATH }}
+        retention-days: 14
+      continue-on-error: true
+
+    - name: Store conda build environment artifacts
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      # only relevant if build failed, see above
+      if: ${{ always() && steps.determine-status.outputs.status == 'failure' && steps.prepare-artifacts.outcome == 'success' }}
+      with:
+        name: ${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_NAME }}
+        path: ${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_PATH }}
+        retention-days: 14
+      continue-on-error: true

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
-azure:
-  store_build_artifacts: true
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64
@@ -15,3 +13,5 @@ provider:
   linux_ppc64le: default
   win: azure
 test: native_and_emulated
+workflow_settings:
+  store_build_artifacts: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - rdkit-stubs.CMakeLists.txt.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   # See https://conda-forge.org/docs/maintainer/knowledge_base/#placing-requirements-in-build-or-host and
@@ -84,15 +84,19 @@ outputs:
   - name: librdkit-dev
     script: install.sh  # [unix]
     script: install.bat  # [win]
+    build:
+      run_exports:
+        - {{ pin_compatible('eigen-abi', max_pin='x.x.x.x') }}
     requirements:
       build:
         - {{ stdlib("c") }}
         - cmake
+      host:
+        - eigen-abi-devel
       run:
         - {{ pin_subpackage('librdkit', exact=True) }}
         - eigen-abi-devel
-      run_exports:
-        - ${{ pin_compatible('eigen-abi', upper_bound='x.x.x.x') }}    test:
+    test:
       commands:
         - test -f $PREFIX/include/rdkit/GraphMol/GraphMol.h               # [unix]
         - if not exist %LIBRARY_INC%\\rdkit\\GraphMol\\GraphMol.h exit 1  # [win]


### PR DESCRIPTION
## Summary

Two unrelated cleanup fixes that surfaced while doing a pass over the recipe.

### 1. Fix malformed `librdkit-dev` `run_exports` and `test:` block

PR #215 (eigen v5 migration) introduced a malformed block in the `librdkit-dev` output by copying the [eigen-feedstock README Section C template](https://github.com/conda-forge/eigen-feedstock/blob/b23c3f3f4527e8b3cbcdd496dae888c358489244/recipe/README.md) verbatim. That template is written in **rattler-build v1** syntax, but this recipe is in **v0 conda-build** format. A dropped newline also concatenated `test:` onto the `run_exports` value:

```yaml
      run_exports:
        - ${{ pin_compatible('eigen-abi', upper_bound='x.x.x.x') }}    test:
      commands:
        - test -f $PREFIX/include/rdkit/GraphMol/GraphMol.h               # [unix]
        - if not exist %LIBRARY_INC%\\rdkit\\GraphMol\\GraphMol.h exit 1  # [win]
```

Net effect of the existing code:
- The `eigen-abi` `run_exports` is **not applied** — `${{ ... }}` is Jinja-passed through verbatim and never expanded.
- The `librdkit-dev` `test:` block **never runs** — `commands:` is parsed under `requirements:`, where conda-build silently ignores it. The header-existence checks have been silently skipped since #215 merged.

Fix:
- Move `run_exports` into its own `build:` block (matches the `librdkit` output pattern).
- Use v0 Jinja `{{ }}` instead of v1 `${{ }}`.
- Use `max_pin='x.x.x.x'` (v0 conda-build kwarg) instead of `upper_bound='x.x.x.x'` (v1 / rattler-build kwarg).
- Restore `test:` as a proper top-level key of the output so the header existence checks actually run.
- Add `eigen-abi-devel` to `host:` so `pin_compatible('eigen-abi', ...)` can resolve at build time.
- Bump build number 1 → 2.

### 2. Migrate deprecated `azure.store_build_artifacts` → `workflow_settings.store_build_artifacts`

The conda-forge.yml linter has been failing on every PR with:

> ❌ In conda-forge.yml: `$.azure` = `{'store_build_artifacts': True}`. `{'store_build_artifacts': True} is not valid under any of the given schemas`

The `azure.store_build_artifacts` field is deprecated; the new location per the [schema](https://conda-forge.org/docs/maintainer/conda_forge_yml/) is `workflow_settings.store_build_artifacts`. Migrating drops the lint and removes the now-empty `azure:` block.

**Heads up — behavioral side effect:** the re-render output shows that `STORE_BUILD_ARTIFACTS` flips from `False` to `True` for all Linux matrix entries in `.github/workflows/conda-build.yml`. The previous `azure.store_build_artifacts: true` setting was effectively a no-op for Linux (which builds on GHA, not Azure); the new `workflow_settings.*` setting is properly cross-platform, so GHA Linux builds will now upload build artifacts on each run. This is the *intent* of the original setting, just finally taking effect. Worth confirming this is desired before merge.

## Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number
* [x] [Re-rendered](https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) with the latest `conda-smithy` (commit `e4aa523`)
* [x] Ensured the license file is being packaged

## Test plan

- [x] CI builds successfully across all variants (31/31 SUCCESS)
- [x] Verified `librdkit-dev` test commands actually execute in the build logs — `TEST START: .../librdkit-dev-2026.03.2-hb1379ee_2.conda` followed by `+ test -f .../include/rdkit/GraphMol/GraphMol.h` (had been silently skipped since #215)
- [x] Confirmed the `eigen-abi` `run_exports` is applied — build logs show the `librdkit-dev` output with `build.run_exports: - eigen-abi` and the resolved constraint `eigen-abi >=5.0.1.80,<5.0.1.81.0a0` (i.e. `max_pin='x.x.x.x'` working as intended)
- [x] Confirmed the conda-forge.yml schema lint no longer fires — second linter comment reports the recipe is in "excellent condition"
- [x] Confirmed GHA Linux runs upload `conda_pkgs_*` artifacts — 15 artifacts uploaded by [run 25772213614](https://github.com/skearnes/rdkit-feedstock/actions/runs/25772213614), one per Linux variant × Python version

🤖 Generated with [Claude Code](https://claude.com/claude-code)