### PR TITLE
Add run_exports to the rdkit Python output

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,7 +110,7 @@ outputs:
     script: install.bat  # [win]
     build:
       run_exports:
-        - {{ pin_subpackage('rdkit', max_pin='x.x') }}
+        - {{ pin_subpackage('rdkit', exact=True) }}
     requirements:
       build:
         - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - rdkit-stubs.CMakeLists.txt.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   # See https://conda-forge.org/docs/maintainer/knowledge_base/#placing-requirements-in-build-or-host and
@@ -108,6 +108,9 @@ outputs:
   - name: rdkit
     script: install.sh  # [unix]
     script: install.bat  # [win]
+    build:
+      run_exports:
+        - {{ pin_subpackage('rdkit', max_pin='x.x') }}
     requirements:
       build:
         - {{ compiler('cxx') }}


### PR DESCRIPTION
## Summary

The `rdkit` Python output ([recipe/meta.yaml:108-178](recipe/meta.yaml#L108-L178)) has no `run_exports` declaration. This means Python-consumer feedstocks that depend on `rdkit` get no automatic version constraint when their packages are installed alongside a new rdkit.

If rdkit bumps a major version with a Python API break — per [@greglandrum on conda-forge/conda-forge-pinning-feedstock#5719](https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/5719#issuecomment-2113998373), this is possible across `.03`/`.09` major releases — pre-built downstream packages would silently fail at runtime because they were never told which rdkit versions they're compatible with.

This PR adds:

```yaml
  - name: rdkit
    ...
    build:
      run_exports:
        - {{ pin_subpackage('rdkit', exact=True) }}
```

Matches the existing convention in this recipe — `librdkit`'s `run_exports` at [recipe/meta.yaml:62-63](recipe/meta.yaml#L62-L63) also uses `exact=True`. Conservative by default given Greg's stated upstream policy ("you'll probably need to recompile code that depends on the libraries when the version of the underlying library changes"). Downstream rebuilds will happen anyway through the broader migration cycle (eigen, libboost, python).

## What it does and doesn't do

- ✅ **At install time**, a feedstock built with `rdkit` in `host:` gets pinned to the exact rdkit build at runtime. No more silent runtime breaks when users install a freshly-bumped rdkit alongside an older downstream package.
- ❌ **Does not** trigger automated rebuild PRs for Python downstreams on each rdkit bump. That would require also adding `rdkit` to the [global pinning](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml), which would generate ~30 rebuild PRs per `.03`/`.09` cycle — judged not worth the bot churn for Python-only API consumers.

## Coordination

Independent of [conda-forge/conda-forge-pinning-feedstock#8496](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8496) (adds `librdkit` to global pinning for build-time C++ consumers). Together they cover the API + ABI sides cleanly:
- C++ consumers (chemicalite, cuik-molmaker, rdchiral_cpp, grouper) → ABI tracked via global pin + librdkit run_exports
- Python consumers (~30 feedstocks) → API tracked via this PR's run_exports

## Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number
* [ ] [Re-rendered](https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) with the latest `conda-smithy` — opening as draft to confirm approach first
* [x] Ensured the license file is being packaged

## Test plan

- [ ] conda-forge CI green across all variants
- [ ] Confirm `rdkit-2026.03.2-*.conda` `info/run_exports.json` includes the exact-pin entry for `rdkit`
- [ ] No regression — this is additive and doesn't change build behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)