### PR TITLE
Move headers and cmake config files into librdkit-dev

### DIFF
--- a/recipe/dev-component-tagging.patch
+++ b/recipe/dev-component-tagging.patch
@@ -1,0 +1,54 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4066d7e3e..518ba24df 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -616,6 +616,7 @@ install(
+   FILE ${RDKit_EXPORTED_TARGETS}.cmake
+   NAMESPACE RDKit::
+   DESTINATION ${RDKit_LibDir}/cmake/rdkit
++  COMPONENT dev
+ )
+ 
+ # create and install package configuration and version files
+@@ -632,7 +633,8 @@ configure_file (
+ install(FILES
+     ${RDKit_BINARY_DIR}/rdkit-config.cmake
+     ${RDKit_BINARY_DIR}/rdkit-config-version.cmake
+-    DESTINATION ${RDKit_LibDir}/cmake/rdkit)
++    DESTINATION ${RDKit_LibDir}/cmake/rdkit
++    COMPONENT dev)
+ 
+ # then manage the targets for the python bindings
+ if(RDK_BUILD_PYTHON_WRAPPERS)
+@@ -641,6 +643,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
+     FILE ${RDKitPython_EXPORTED_TARGETS}.cmake
+     NAMESPACE RDKit::
+     DESTINATION ${RDKit_LibDir}/cmake/rdkitpython
++    COMPONENT dev
+   )
+ 
+   write_basic_package_version_file(
+@@ -656,7 +659,8 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
+   install(FILES
+     ${RDKit_BINARY_DIR}/rdkitpython-config.cmake
+     ${RDKit_BINARY_DIR}/rdkitpython-config-version.cmake
+-    DESTINATION ${RDKit_LibDir}/cmake/rdkitpython)
++    DESTINATION ${RDKit_LibDir}/cmake/rdkitpython
++    COMPONENT dev)
+ endif(RDK_BUILD_PYTHON_WRAPPERS)
+ 
+ # Memory testing setup
+diff --git a/Code/RDGeneral/CMakeLists.txt b/Code/RDGeneral/CMakeLists.txt
+index c05545310..4f302df01 100644
+--- a/Code/RDGeneral/CMakeLists.txt
++++ b/Code/RDGeneral/CMakeLists.txt
+@@ -55,7 +55,8 @@ rdkit_headers(Exceptions.h
+         DEST RDGeneral)
+ 
+ if (NOT RDK_INSTALL_INTREE)
+-    install(DIRECTORY hash DESTINATION ${RDKit_HdrDir}/RDGeneral)
++    install(DIRECTORY hash DESTINATION ${RDKit_HdrDir}/RDGeneral
++            COMPONENT dev)
+ endif (NOT RDK_INSTALL_INTREE)
+ 
+ rdkit_catch_test(testDict testDict.cpp LINK_LIBRARIES RDGeneral)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,8 @@ source:
     - rdkit-stubs.CMakeLists.txt.patch
     # Backport of rdkit/rdkit#9287. Tags dev-only install rules with COMPONENT
     # dev so the hash headers and cmake config/export files land in
-    # librdkit-dev instead of leaking into librdkit. Drop once #9287 ships.
+    # librdkit-dev instead of leaking into librdkit. Drop on the next rdkit
+    # version bump that includes rdkit/rdkit#9287.
     - dev-component-tagging.patch
 
 build:
@@ -80,6 +81,11 @@ outputs:
         - test -f $PREFIX/lib/libRDKitGraphMol.so              # [linux]
         - test -f $PREFIX/lib/libRDKitGraphMol.dylib           # [osx]
         - if not exist %LIBRARY_BIN%\RDKitGraphMol.dll exit 1  # [win]
+        # Dev-only artifacts should live in librdkit-dev, not here.
+        - test ! -e $PREFIX/lib/cmake/rdkit/rdkit-config.cmake               # [unix]
+        - test ! -e $PREFIX/include/rdkit/RDGeneral/hash/hash.hpp            # [unix]
+        - if exist %LIBRARY_LIB%\cmake\rdkit\rdkit-config.cmake exit 1       # [win]
+        - if exist %LIBRARY_INC%\rdkit\RDGeneral\hash\hash.hpp exit 1        # [win]
     about:
       summary: RDKit C++ library
       license: BSD-3-Clause
@@ -104,6 +110,11 @@ outputs:
       commands:
         - test -f $PREFIX/include/rdkit/GraphMol/GraphMol.h               # [unix]
         - if not exist %LIBRARY_INC%\\rdkit\\GraphMol\\GraphMol.h exit 1  # [win]
+        # Cmake config and hash headers must live here, not in librdkit.
+        - test -f $PREFIX/lib/cmake/rdkit/rdkit-config.cmake                  # [unix]
+        - test -f $PREFIX/include/rdkit/RDGeneral/hash/hash.hpp               # [unix]
+        - if not exist %LIBRARY_LIB%\\cmake\\rdkit\\rdkit-config.cmake exit 1 # [win]
+        - if not exist %LIBRARY_INC%\\rdkit\\RDGeneral\\hash\\hash.hpp exit 1 # [win]
     about:
       summary: RDKit headers and library used in librdkit
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,13 @@ source:
     - pyproject.patch
     - rdkit-postgresql-osx-linker-flags.patch
     - rdkit-stubs.CMakeLists.txt.patch
+    # Backport of rdkit/rdkit#9287. Tags dev-only install rules with COMPONENT
+    # dev so the hash headers and cmake config/export files land in
+    # librdkit-dev instead of leaking into librdkit. Drop once #9287 ships.
+    - dev-component-tagging.patch
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   # See https://conda-forge.org/docs/maintainer/knowledge_base/#placing-requirements-in-build-or-host and

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,10 +82,10 @@ outputs:
         - test -f $PREFIX/lib/libRDKitGraphMol.dylib           # [osx]
         - if not exist %LIBRARY_BIN%\RDKitGraphMol.dll exit 1  # [win]
         # Dev-only artifacts should live in librdkit-dev, not here.
-        - test ! -e $PREFIX/lib/cmake/rdkit/rdkit-config.cmake               # [unix]
-        - test ! -e $PREFIX/include/rdkit/RDGeneral/hash/hash.hpp            # [unix]
-        - if exist %LIBRARY_LIB%\cmake\rdkit\rdkit-config.cmake exit 1       # [win]
-        - if exist %LIBRARY_INC%\rdkit\RDGeneral\hash\hash.hpp exit 1        # [win]
+        - test ! -e $PREFIX/lib/cmake/rdkit/rdkit-config.cmake  # [unix]
+        - test ! -e $PREFIX/include/rdkit/RDGeneral/hash/hash.hpp  # [unix]
+        - if exist %LIBRARY_LIB%\cmake\rdkit\rdkit-config.cmake exit 1  # [win]
+        - if exist %LIBRARY_INC%\rdkit\RDGeneral\hash\hash.hpp exit 1  # [win]
     about:
       summary: RDKit C++ library
       license: BSD-3-Clause
@@ -111,10 +111,10 @@ outputs:
         - test -f $PREFIX/include/rdkit/GraphMol/GraphMol.h               # [unix]
         - if not exist %LIBRARY_INC%\\rdkit\\GraphMol\\GraphMol.h exit 1  # [win]
         # Cmake config and hash headers must live here, not in librdkit.
-        - test -f $PREFIX/lib/cmake/rdkit/rdkit-config.cmake                  # [unix]
-        - test -f $PREFIX/include/rdkit/RDGeneral/hash/hash.hpp               # [unix]
-        - if not exist %LIBRARY_LIB%\\cmake\\rdkit\\rdkit-config.cmake exit 1 # [win]
-        - if not exist %LIBRARY_INC%\\rdkit\\RDGeneral\\hash\\hash.hpp exit 1 # [win]
+        - test -f $PREFIX/lib/cmake/rdkit/rdkit-config.cmake  # [unix]
+        - test -f $PREFIX/include/rdkit/RDGeneral/hash/hash.hpp  # [unix]
+        - if not exist %LIBRARY_LIB%\\cmake\\rdkit\\rdkit-config.cmake exit 1  # [win]
+        - if not exist %LIBRARY_INC%\\rdkit\\RDGeneral\\hash\\hash.hpp exit 1  # [win]
     about:
       summary: RDKit headers and library used in librdkit
       license: BSD-3-Clause


### PR DESCRIPTION
## Summary

- Backport rdkit/rdkit#9287 as `recipe/dev-component-tagging.patch` to tag 5 dev-only `install()` calls with `COMPONENT dev`.
- Bump build number 3 → 4 to rebuild against the new file layout.

After this PR, the following files move from `librdkit` (runtime) to `librdkit-dev`:

| Files | Currently in | After this PR |
|---|---|---|
| `include/rdkit/RDGeneral/hash/*.hpp` (5 files) | `librdkit` | `librdkit-dev` |
| `lib/cmake/rdkit/*.cmake` (4 files) | `librdkit` | `librdkit-dev` |
| `lib/cmake/rdkitpython/*.cmake` (4 files) | `librdkit` | `librdkit-dev` |

## Motivation

Resolves the headers/cmake-files half of #164. Verified in [comment 2226107667 on PR #158](https://github.com/conda-forge/rdkit-feedstock/pull/158#issuecomment-2226107667) by @jaimergp, and confirmed still present in `librdkit-2026.03.2-hb1379ee_3`. The cmake-config leak is the worse half: `librdkit-dev` currently ships **zero** `.cmake` files, so `find_package(RDKit)` against just `librdkit-dev` fails. Downstream feedstocks that want headers + cmake config have to pull `librdkit` directly, partially defeating the librdkit/librdkit-dev split landed in #190.

Root cause: 5 upstream `install()` calls install dev-only artifacts without an explicit `COMPONENT` and default to `Unspecified`. Our `librdkit` recipe installs `Unspecified base data runtime`, so those files leak there.

## Why a patch and not a recipe change

No recipe change is needed:

- All outputs (`librdkit`, `librdkit-dev`, `rdkit`, `rdkit-postgresql`) share one cmake build tree (`build.sh` does a single configure + make). None of them does `find_package(RDKit)` — they all harvest different components from the same shared build. So the file relocation has no effect on the feedstock's own build.
- `librdkit-dev` must still run-depend on `librdkit`: the cmake export files reference the actual `.so` targets, which live in `librdkit`. Anyone who installs only `librdkit-dev` would have `find_package(RDKit)` succeed but the linker fail. The existing `run: librdkit` line on `librdkit-dev` stays.

The downstream benefit accrues to *other* feedstocks: after this PR, they can `host: librdkit-dev` and have `find_package(RDKit)` work. Before, they had to depend on `librdkit` directly because that's where the cmake config lived.

## Upstream

Backports rdkit/rdkit#9287. Once that ships in an upstream release, drop `dev-component-tagging.patch` from the patches list. A comment in `meta.yaml` notes this.

## Test plan

- [x] Verified the patch applies cleanly to the v2026_03_2 source tarball (no rejects, no fuzz).
- [x] Verified `COMPONENT dev` semantics with a minimal cmake project (default install unchanged; `CMAKE_INSTALL_COMPONENT=dev` picks up the tagged files; `CMAKE_INSTALL_COMPONENT=Unspecified` does not — which is the bug).
- [ ] CI: confirm `librdkit-dev` gains the cmake config files and `librdkit` loses them.
- [ ] CI: confirm existing `librdkit-dev` headers test (`test -f $PREFIX/include/rdkit/GraphMol/GraphMol.h`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
