### PR TITLE
Route rdkitpython cmake config files into the rdkit package (closes #227)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,14 @@ source:
     # librdkit-dev instead of leaking into librdkit. Drop on the next rdkit
     # version bump that includes rdkit/rdkit#9287.
     - dev-component-tagging.patch
+    # Backport of rdkit/rdkit#9288. Refines the two rdkitpython install rules
+    # to COMPONENT python so the python-version-coupled cmake config files
+    # land with the python wrappers rather than in librdkit-dev. See #227.
+    # Drop on the next rdkit version bump that includes rdkit/rdkit#9288.
+    - rdkitpython-component-python.patch
 
 build:
-  number: 5
+  number: 6
 
 requirements:
   # See https://conda-forge.org/docs/maintainer/knowledge_base/#placing-requirements-in-build-or-host and
@@ -115,6 +120,9 @@ outputs:
         - test -f $PREFIX/include/rdkit/RDGeneral/hash/hash.hpp  # [unix]
         - if not exist %LIBRARY_LIB%\\cmake\\rdkit\\rdkit-config.cmake exit 1  # [win]
         - if not exist %LIBRARY_INC%\\rdkit\\RDGeneral\\hash\\hash.hpp exit 1  # [win]
+        # Python-coupled cmake config must live in the rdkit (python) output, not here.
+        - test ! -e $PREFIX/lib/cmake/rdkitpython/rdkitpython-config.cmake  # [unix]
+        - if exist %LIBRARY_LIB%\\cmake\\rdkitpython\\rdkitpython-config.cmake exit 1  # [win]
     about:
       summary: RDKit headers and library used in librdkit
       license: BSD-3-Clause
@@ -170,6 +178,9 @@ outputs:
         # Test the availability of Contrib.
         - python -c "import os; import sys; sys.path.append(os.path.join(os.environ['CONDA_PREFIX'], 'share', 'RDKit', 'Contrib')); from SA_Score import sascorer"  # [unix]
         - python -c "import os; import sys; sys.path.append(os.path.join(os.environ['CONDA_PREFIX'], 'Library', 'share', 'RDKit', 'Contrib')); from SA_Score import sascorer"  # [win]
+        # Python-coupled cmake config must live here, not in librdkit-dev.
+        - test -f $PREFIX/lib/cmake/rdkitpython/rdkitpython-config.cmake  # [unix]
+        - if not exist %LIBRARY_LIB%\\cmake\\rdkitpython\\rdkitpython-config.cmake exit 1  # [win]
       imports:
         - rdkit
         - rdkit.Avalon

--- a/recipe/rdkitpython-component-python.patch
+++ b/recipe/rdkitpython-component-python.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 518ba24..f64b300 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -643,7 +643,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
+     FILE ${RDKitPython_EXPORTED_TARGETS}.cmake
+     NAMESPACE RDKit::
+     DESTINATION ${RDKit_LibDir}/cmake/rdkitpython
+-    COMPONENT dev
++    COMPONENT python
+   )
+ 
+   write_basic_package_version_file(
+@@ -660,7 +660,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
+     ${RDKit_BINARY_DIR}/rdkitpython-config.cmake
+     ${RDKit_BINARY_DIR}/rdkitpython-config-version.cmake
+     DESTINATION ${RDKit_LibDir}/cmake/rdkitpython
+-    COMPONENT dev)
++    COMPONENT python)
+ endif(RDK_BUILD_PYTHON_WRAPPERS)
+ 
+ # Memory testing setup


### PR DESCRIPTION
## Summary

Resolves #227 by backporting rdkit/rdkit#9288 as `recipe/rdkitpython-component-python.patch`. Refines the two `rdkitpython-*` install rules to `COMPONENT python` (already tagged `COMPONENT dev` by the existing `dev-component-tagging.patch`), so they route into the `rdkit` (python) output instead of `librdkit-dev`.

| File | Currently in | After this PR |
|---|---|---|
| `lib/cmake/rdkitpython/rdkitpython-config.cmake` | `librdkit-dev` | `rdkit` |
| `lib/cmake/rdkitpython/rdkitpython-config-version.cmake` | `librdkit-dev` | `rdkit` |
| `lib/cmake/rdkitpython/rdkitpython-targets.cmake` | `librdkit-dev` | `rdkit` |
| `lib/cmake/rdkitpython/rdkitpython-targets-release.cmake` | `librdkit-dev` | `rdkit` |

## Motivation

These cmake files hardcode a single python version at upstream-RDKit build configure time:

```cmake
find_dependency(Python3 3.12 COMPONENTS Interpreter Development.Module NumPy)
find_dependency(Boost 1.90.0 COMPONENTS python312 numpy312)
```

`librdkit-dev` is python-agnostic (one build per platform). Shipping a python-version-specific cmake file in a python-agnostic package means users running a different python version get a `find_package(RDKitPython)` that fails on the `Boost ... python312 numpy312` line (conda-forge ships boost per python version).

The `rdkit` (python) output is already python-version-specific, so it's the natural home for these files. As a bonus, this also resolves a pre-existing latent issue: `rdkitpython-targets.cmake` references `RDKit::RDBoost`, whose binary (`libRDKitRDBoost.dylib` / `.dll`) already lives in `rdkit`, not `librdkit`. After this PR, the cmake config and the binaries it references finally live together.

Details and platform-by-platform verification in #227.

## Approach: incremental patch

Rather than modifying `dev-component-tagging.patch`, this adds a second patch (`rdkitpython-component-python.patch`) that gets applied after it. The new patch flips just the two rdkitpython install rules from `COMPONENT dev` → `COMPONENT python`. This mirrors how the two upstream PRs will land in sequence (rdkit/rdkit#9287 first, then #9288 as a refinement) and makes it trivial to drop either patch independently when its corresponding upstream PR ships.

## Test plan

Verified the patches apply cleanly in sequence to the v2026_03_2 source tarball — no rejects, no fuzz. End-state contains `COMPONENT dev` on rdkit-* install rules and `COMPONENT python` on rdkitpython-* install rules.

- [x] Both patches apply cleanly on top of v2026_03_2 (manual verification).
- [ ] CI: all platforms build green.
- [ ] CI: the new tests on `librdkit-dev` (assert absence of `rdkitpython-config.cmake`) and `rdkit` (assert presence) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)